### PR TITLE
Swap release order (release then sbom)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,13 @@ jobs:
         id: tag
         run: echo "tag_name=${GITHUB_REF#refs/*/}" >> "$GITHUB_OUTPUT"
 
+      - name: Publish Release
+        uses: kubernetes-sigs/release-actions/publish-release@8753ea6bdadb814d779c6ec34eaca689dbfb492b # v0.4.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          sbom: false
+
       - name: Generate SBOM
         id: sbom
         uses: carabiner-dev/actions/unpack/sbom@73e94b6ec4adbf65bb7b9f4ecec334dc6576553f # v1.1.6
@@ -42,10 +49,3 @@ jobs:
           push-to-release: ${{ steps.tag.outputs.tag_name }}
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - name: Publish Release
-        uses: kubernetes-sigs/release-actions/publish-release@8753ea6bdadb814d779c6ec34eaca689dbfb492b # v0.4.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          sbom: false


### PR DESCRIPTION
This pull request makes a minor adjustment to the release workflow by reordering the steps for publishing a release and generating the SBOM in `.github/workflows/release.yaml`. The "Publish Release" step is now executed before the "Generate SBOM" step, but there are no changes to the logic or configuration of either step.