### PR TITLE
Localpatg

### DIFF
--- a/localpath_test.go
+++ b/localpath_test.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: Copyright 2026 Carabiner Systems, Inc
+// SPDX-License-Identifier: Apache-2.0
+
+package vcslocator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFromPath(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		path string
+		want Locator
+	}{
+		{"posix-absolute", "/tmp/repo", Locator("file:///tmp/repo")},
+		{"posix-nested", "/home/user/projects/repo", Locator("file:///home/user/projects/repo")},
+		{"posix-relative", "repo", Locator("file:///repo")},
+		{"windows-backslash", `C:\Users\x\repo`, Locator("file:///C:/Users/x/repo")},
+		{"windows-forwardslash", "C:/Users/x/repo", Locator("file:///C:/Users/x/repo")},
+		{"windows-lowercase-drive", `d:\repo`, Locator("file:///d:/repo")},
+		{"windows-mixed-slashes", `C:\Users/x\repo`, Locator("file:///C:/Users/x/repo")},
+		{"empty", "", Locator("file://")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, NewFromPath(tc.path))
+		})
+	}
+}
+
+// TestNewFromPathRoundTrip ensures NewFromPath and Locator.LocalPath are
+// inverses: feeding LocalPath's output back through NewFromPath (and vice
+// versa) produces a stable value. This guards the platform-specific slash
+// handling since both operations must agree on the Windows drive-letter
+// convention.
+func TestNewFromPathRoundTrip(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"posix", "/tmp/repo"},
+		{"windows-drive", "C:/Users/x/repo"},
+		{"windows-lowercase", "d:/repo"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			loc := NewFromPath(tc.path)
+			got, err := loc.LocalPath()
+			require.NoError(t, err)
+			require.Equal(t, tc.path, got)
+		})
+	}
+}
+
+func TestLocatorLocalPath(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name    string
+		locator Locator
+		want    string
+		mustErr bool
+	}{
+		// file:// URLs must return a usable native filesystem path on every
+		// platform — go-git, os.Open, etc. treat the leading "/C:/..." form
+		// as drive-relative on Windows, so it must be stripped.
+		{"posix-absolute", Locator("file:///tmp/repo"), "/tmp/repo", false},
+		{"posix-with-ref", Locator("file:///tmp/repo@main"), "/tmp/repo", false},
+		{"posix-with-subpath", Locator("file:///tmp/repo#sub"), "/tmp/repo", false},
+		{"windows-drive", Locator("file:///C:/Users/x/repo"), "C:/Users/x/repo", false},
+		{"windows-drive-lowercase", Locator("file:///d:/repo"), "d:/repo", false},
+		{"windows-drive-with-ref", Locator("file:///C:/repo@abc123"), "C:/repo", false},
+		{"windows-drive-with-subpath", Locator("file:///C:/repo#sub/dir"), "C:/repo", false},
+
+		// Non-file transports: LocalPath is not meaningful, return "".
+		{"https", Locator("https://github.com/example/test"), "", false},
+		{"ssh", Locator("ssh://git@github.com/example/test"), "", false},
+		{"slug", Locator("example/test"), "", false},
+
+		// Parse errors propagate.
+		{"empty", Locator(""), "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := tc.locator.LocalPath()
+			if tc.mustErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/locator.go
+++ b/locator.go
@@ -43,6 +43,43 @@ var sha1Regex, sha1ShortRegex *regexp.Regexp
 // Locator is a type that wraps a VCS locator string to add functionality to it.
 type Locator string
 
+// NewFromPath builds a file:// Locator from a native filesystem path. It is
+// the inverse of Locator.LocalPath: backslashes are normalized to forward
+// slashes, and Windows drive-letter paths (e.g. "C:\foo\bar") are prefixed
+// with an extra slash so the drive letter isn't parsed as a URL scheme
+// (file:///C:/foo/bar). The input is treated as a pure filesystem path;
+// "@ref" or "#subpath" suffixes are not interpreted.
+func NewFromPath(path string) Locator {
+	// Always normalize backslashes so Windows paths work regardless of the
+	// host GOOS (filepath.ToSlash is a no-op on non-Windows).
+	p := strings.ReplaceAll(path, `\`, "/")
+	if p != "" && !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return Locator("file://" + p)
+}
+
+// LocalPath returns the native filesystem path for a file:// locator, suitable
+// for passing to os.Open, go-git's PlainOpen, and other local-path APIs. On
+// Windows the parsed path takes the URL form "/C:/foo/bar"; this returns
+// "C:/foo/bar" so the path isn't misread as drive-relative. For locators whose
+// transport is not "file" the return value is an empty string. Returns an
+// error only if the locator fails to parse.
+func (l Locator) LocalPath(funcs ...fnOpt) (string, error) {
+	components, err := l.Parse(funcs...)
+	if err != nil {
+		return "", err
+	}
+	if components.Transport != TransportFile {
+		return "", nil
+	}
+	p := components.RepoPath
+	if len(p) >= 3 && p[0] == '/' && p[2] == ':' {
+		p = p[1:]
+	}
+	return p, nil
+}
+
 const slugRegexPattern = `^[-A-Za-z0-9_]+/[-A-Za-z0-9_]+$`
 
 var slugRegex *regexp.Regexp


### PR DESCRIPTION
This pull request adds comprehensive support for converting between native filesystem paths and `file://` VCS locators, with thorough handling for both POSIX and Windows path conventions. It introduces new helper methods and a suite of tests to ensure correctness and round-trip consistency across platforms.

**Path conversion and normalization improvements:**

* Added the `NewFromPath` function to construct a `file://` `Locator` from a native filesystem path, normalizing slashes and handling Windows drive letters to ensure valid URL formatting. (`locator.go`, [locator.goR46-R82](diffhunk://#diff-e59b297f3852595df0eb0f1ea10e423c305037609718f4d05fcdd1a330c80d9eR46-R82))
* Implemented the `LocalPath` method for the `Locator` type, which returns the native filesystem path from a `file://` locator, stripping the leading slash on Windows drive-letter paths and returning an empty string for non-file transports. (`locator.go`, [locator.goR46-R82](diffhunk://#diff-e59b297f3852595df0eb0f1ea10e423c305037609718f4d05fcdd1a330c80d9eR46-R82))

**Testing and validation:**

* Introduced a new test file, `localpath_test.go`, containing comprehensive tests for both `NewFromPath` and `Locator.LocalPath`, including round-trip invariance and platform-specific edge cases. (`localpath_test.go`, [localpath_test.goR1-R98](diffhunk://#diff-d4cbe6b0e34cf90fe0964ac4564cd995ccbb325350ec8948a859b6147f2f3dedR1-R98))