### PR TITLE
get: wire opts from CopyFileGroup to CloneRepository

### DIFF
--- a/get.go
+++ b/get.go
@@ -91,7 +91,7 @@ func CopyFileGroup[T ~string](locators []T, writers []io.Writer, funcs ...fnOpt)
 	t := throttler.New(4, len(cloneList))
 	for repostring, copyplan := range cloneList {
 		go func(repostring string, copyplan *copyPlan) {
-			fsobj, err := CloneRepository(copyplan.Locator)
+			fsobj, err := CloneRepository(copyplan.Locator, funcs...)
 			mutex.Lock()
 			cloneList[repostring].FS = fsobj
 			mutex.Unlock()


### PR DESCRIPTION
This Pr fixes a bug where options where no propagated to clonerepository