### PR TITLE
Update golangci-lint to v2.13

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -44,4 +44,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11
+          version: v2.13

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -110,6 +110,8 @@ linters:
     - zerologlint
 
   settings:
+    goconst:
+      ignore-tests: true
     gocyclo:
       min-complexity: 35
     godox:

--- a/components.go
+++ b/components.go
@@ -24,7 +24,7 @@ type Components struct {
 // RepoURL forms the repository URL to clone based on the defined components
 func (c *Components) RepoURL() string {
 	switch c.Transport {
-	case "https", "":
+	case TransportHTTPS, "":
 		return fmt.Sprintf("https://%s/%s", c.Hostname, strings.TrimPrefix(c.RepoPath, "/"))
 	case "ssh":
 		return fmt.Sprintf("git@%s:%s", c.Hostname, strings.TrimPrefix(c.RepoPath, "/"))

--- a/locator.go
+++ b/locator.go
@@ -121,8 +121,8 @@ func (l Locator) Parse(funcs ...fnOpt) (*Components, error) {
 		if slugRegex.MatchString(path) {
 			tag, branch, commitSha := parseRefString(ref, &opts)
 			return &Components{
-				Tool:      "git",
-				Transport: "https",
+				Tool:      ToolGit,
+				Transport: TransportHTTPS,
 				Hostname:  "github.com",
 				RepoPath:  path,
 				RefString: ref,
@@ -141,7 +141,7 @@ func (l Locator) Parse(funcs ...fnOpt) (*Components, error) {
 	// Synth the file schema to capture all into the path early
 	if transportIsFile {
 		transp = TransportFile
-		tool = "git"
+		tool = ToolGit
 		si = true
 	}
 
@@ -224,7 +224,7 @@ func CloneRepository[T ~string](locator T, funcs ...fnOpt) (fs.FS, error) {
 		return nil, fmt.Errorf("parsing locator: %w", err)
 	}
 
-	if components.Tool != "git" {
+	if components.Tool != ToolGit {
 		return nil, errors.New("only git locators are supported for cloning")
 	}
 
@@ -475,7 +475,7 @@ func remoteURLToLocator(rawURL, ref string) (string, error) {
 	path := strings.TrimSuffix(strings.TrimPrefix(u.Path, "/"), ".git")
 
 	switch u.Scheme {
-	case "https", "http":
+	case TransportHTTPS, "http":
 		return fmt.Sprintf("git+https://%s/%s@%s", u.Hostname(), path, ref), nil
 	case "ssh":
 		return fmt.Sprintf("git+ssh://%s/%s@%s", u.Hostname(), path, ref), nil


### PR DESCRIPTION
Bumps the golangci-lint version pinned in the repository's lint workflow(s) from v2.11 to v2.13.

Latest release: https://github.com/golangci/golangci-lint/releases/tag/v2.13.1

Signed-off-by: Biner <biner@carabiner.dev>
